### PR TITLE
Subscription: Add beta features

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -359,6 +359,7 @@ module StripeMock
         trial_start: 1308595038,
         trial_end: 1308681468,
         customer: 'c_test_customer',
+        on_behalf_of: nil,
         quantity: 1,
         tax_percent: nil,
         discount: nil,

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -122,6 +122,10 @@ module StripeMock
           subscription[:on_behalf_of] = params[:on_behalf_of]
         end
 
+        if params[:transfer_data]
+          subscription[:transfer_data] = params[:transfer_data]
+        end
+
         if params[:coupon]
           coupon_id = params[:coupon]
 

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -102,7 +102,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval default_payment_method collection_method)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key enable_incomplete_payments cancel_at_period_end default_tax_rates payment_behavior pending_invoice_item_interval default_payment_method collection_method on_behalf_of transfer_data)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)
@@ -117,6 +117,10 @@ module StripeMock
         # Ensure customer has card to charge if plan has no trial and is not free
         # Note: needs updating for subscriptions with multiple plans
         verify_card_present(customer, subscription_plans.first, subscription, params)
+
+        if params[:on_behalf_of]
+          subscription[:on_behalf_of] = params[:on_behalf_of]
+        end
 
         if params[:coupon]
           coupon_id = params[:coupon]

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -117,6 +117,48 @@ shared_examples 'Customer Subscriptions' do
       expect(subscriptions.data.first.metadata.example).to eq( "yes" )
     end
 
+    it "adds a new subscription with transfer_data" do
+      plan
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+
+      expect(subscriptions.data).to be_empty
+      expect(subscriptions.count).to eq(0)
+
+      sub = Stripe::Subscription.create(
+        plan: 'silver',
+        customer: customer,
+        transfer_data: {
+          destination: "acc_3183912",
+        },
+        metadata: {
+          foo: "bar",
+          example: "yes"
+        }
+      )
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan.to_hash).to eq(plan.to_hash)
+      expect(sub.billing).to eq('charge_automatically')
+      expect(sub.transfer_data["destination"]).to eq("acc_3183912")
+
+      customer = Stripe::Customer.retrieve(customer.id)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      charges = Stripe::Charge.list(customer: customer.id)
+
+      expect(subscriptions.data).to_not be_empty
+      expect(subscriptions.count).to eq(1)
+      expect(subscriptions.data.length).to eq(1)
+      expect(charges.data.length).to eq(1)
+      expect(customer.currency).to eq( "usd" )
+
+      expect(subscriptions.data.first.id).to eq(sub.id)
+      expect(subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
+
+      expect(subscriptions.data.first.customer).to eq(customer.id)
+      expect(subscriptions.data.first.transfer_data.destination).to eq("acc_3183912")
+    end
+
     it "adds a new subscription with on_behalf_of set" do
       plan
       customer = Stripe::Customer.create(source: gen_card_tk)


### PR DESCRIPTION
We're using features that were enabled for us by Stripe but that are not
available here. So I'm adding these features to the gem so we can write
specs with these fields.