### PR TITLE
better emulate Price API IRL

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -586,12 +586,7 @@ module StripeMock
         metadata: {},
         nickname: 'My Mock Price',
         product: "mock_prod_NONEXIST",  # override this with your own existing product id
-        recurring: {
-          aggregate_usage: nil,
-          interval: "month",
-          interval_count: 1,
-          usage_type: "licensed"
-        },
+        recurring: nil,
         tiers_mode: nil,
         transform_quantity: nil,
         type: "recurring",


### PR DESCRIPTION
Like it says on the tin

Why does this need to go? So glad you asked!

`Data.mock_price()` merges our form params into its mocked hash.  CreateProductForm, when the recurring UI flipper is enabled, sends params that look like this: 

```
Started POST "/commerce/products" for 127.0.0.1 at 2020-09-04 09:53:06 -0400
[127.0.0.1] Processing by Commerce::ProductsController#create as JSON
[127.0.0.1]   Parameters: {"name"=>"Home wiring for beginners", "amount"=>"10", "currency"=>"USD", "pricing_type"=>"standard", "product_type"=>"download", "recurring"=>[{"interval"=>"month", "interval_count"=>1}], "file_url"=>"", "file_name"=>"", "path"=>"home-wiring-for-beginners", "domain_id"=>1, "product"=>{"name"=>"Home wiring for beginners"}}
```

`<Digression>`
 That's not a typo. If you look at https://github.com/ConvertKit/convertkit/blob/da2538f5aa30a8a7742a91a0453dbc1015f4003e/app/javascript/pages/products/new.js#L255-L274, you'll see that we currently set a few "default" or initial values for the form to pass on submission, mostly as a Creator convenience.  I know it's a bit weird to see `pricing_type => "standard"` and `recurring=>{...}` together, but from [this slack thread](https://convertkit.slack.com/archives/CGV0K360K/p1599227809314300), I expect params to change a bit before settling.  We'll still have this stripe mock problem though...
`</Digression>`

When IRL Stripe receives a call to create a Stripe Price for a single-pay product, the return looks like this: 
```
# definition.prices...disregard the standard/interval mismatch for a moment:
#<Commerce::Products::Definition::Prices:0x00007fbf91f54800 @definition=#<Commerce::Products::Definitions::None id: 35, type: "Commerce::Products::Definitions::None", product_id: 45, account_id: 9, data: {"amount"=>501, "prices"=>[22], "currency"=>"USD"}, created_at: "2020-09-04 20:19:01", updated_at: "2020-09-04 20:19:01">, @prices=[#<Commerce::Price id: 22, account_id: 9, definition_id: 35, data: {"amount"=>501, "currency"=>"USD", "interval"=>"month", "stripe_key"=>"price_0HNlNA87iriRUvvJ37OM8F8u", "pricing_type"=>"standard", "interval_count"=>1}, created_at: "2020-09-04 20:19:00", updated_at: "2020-09-04 20:19:01">]> 

# from Stripe: 
#<Stripe::Price:0x3fdfc8ecd0a0 id=price_0HNlNA87iriRUvvJ37OM8F8u> JSON: {
  "id": "price_0HNlNA87iriRUvvJ37OM8F8u",
  "object": "price",
  "active": true,
  "billing_scheme": "per_unit",
  "created": 1599250740,
  "currency": "usd",
  "livemode": false,
  "lookup_key": null,
  "metadata": {"commerce_account_id":"9","commerce_definition_id":"35"},
  "nickname": null,
  "product": "prod_HxgkPMRUV2ioaU",
  "recurring": null,
  "tiers_mode": null,
  "transform_quantity": null,
  "type": "one_time",
  "unit_amount": 501,
  "unit_amount_decimal": "501"
}
```

This is because our callback on prices doesn't include a `recurring` key for Stripe unless the pricing_type == recurring, https://github.com/ConvertKit/convertkit/blob/da2538f5aa30a8a7742a91a0453dbc1015f4003e/engines/commerce/models/commerce/price.rb#L24-L29

Since we don't insert a recurring key unless the pricing_type is recurring, the mock price doesn't match IRL.  Setting the key to `nil`, though, gets the job done.

_About that standard/interval mismatch..._  Yeah, I'm not a fan, either/that's a separate PR.  But even when that's addressed, we'll still this issue w `stripe-ruby-mock`.