### PR TITLE
Default to empty hash since tos is optional

### DIFF
--- a/lib/stripe_mock/request_handlers/accounts.rb
+++ b/lib/stripe_mock/request_handlers/accounts.rb
@@ -29,7 +29,7 @@ module StripeMock
         route =~ method_url
         account = assert_existence :account, $1, accounts[$1]
         account.merge!(params)
-        if blank_value?(params[:tos_acceptance], :date)
+        if blank_value?(params.fetch(:tos_acceptance, {}), :date)
           raise Stripe::InvalidRequestError.new("Invalid integer: ", "tos_acceptance[date]", http_status: 400)
         elsif params[:tos_acceptance] && params[:tos_acceptance][:date]
           validate_acceptance_date(params[:tos_acceptance][:date])


### PR DESCRIPTION
It's optional.https://stripe.com/docs/api/accounts/update#update_account-tos_acceptance