### PR TITLE
Subscription: Make cancel_at_period_end act like prod

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -143,6 +143,7 @@ module StripeMock
 
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
+          subscription[:cancel_at] = subscription[:current_period_end]
           subscription[:canceled_at] = Time.now.utc.to_i
         end
 
@@ -207,9 +208,11 @@ module StripeMock
 
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
+          subscription[:cancel_at] = subscription[:current_period_end]
           subscription[:canceled_at] = Time.now.utc.to_i
         elsif params.has_key?(:cancel_at_period_end)
           subscription[:cancel_at_period_end] = false
+          subscription[:cancel_at] = nil
           subscription[:canceled_at] = nil
         end
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -825,6 +825,7 @@ shared_examples 'Customer Subscriptions' do
 
       expect(sub.save).to be_truthy
       expect(sub.cancel_at_period_end).to be_truthy
+      expect(sub.cancel_at).to be_truthy
       expect(sub.canceled_at).to be_truthy
 
       sub.cancel_at_period_end = false
@@ -1137,6 +1138,7 @@ shared_examples 'Customer Subscriptions' do
 
     expect(result.status).to eq('active')
     expect(result.cancel_at_period_end).to eq(true)
+    expect(result.cancel_at).to be_truthy
     expect(result.id).to eq(sub.id)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
@@ -1147,6 +1149,7 @@ shared_examples 'Customer Subscriptions' do
     expect(customer.subscriptions.data.first.status).to eq('active')
     expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(true)
     expect(customer.subscriptions.data.first.ended_at).to be_nil
+    expect(customer.subscriptions.data.first.cancel_at).to_not be_nil
     expect(customer.subscriptions.data.first.canceled_at).to_not be_nil
   end
 
@@ -1173,6 +1176,7 @@ shared_examples 'Customer Subscriptions' do
     expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(false)
     expect(customer.subscriptions.data.first.ended_at).to be_nil
     expect(customer.subscriptions.data.first.canceled_at).to be_nil
+    expect(customer.subscriptions.data.first.cancel_at).to be_nil
   end
 
   it "doesn't change status of subscription when cancelling at period end" do


### PR DESCRIPTION
I just tested production and when setting cancel_at_period_end to true,
it sets the date the period ends in `cancel_at` as well as the other
fields.

This adds that.