### PR TITLE
update mock_invoice for application_fee_amount

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -407,7 +407,7 @@ module StripeMock
         customer: "test_customer",
         object: 'invoice',
         attempted: false,
-        application_fee: nil,
+        application_fee_amount: nil,
         closed: false,
         description: nil,
         forgiven: false,


### PR DESCRIPTION
Based on https://stripe.com/docs/api/invoices/object, it should be `application_fee_amount`, not `application_fee`

I think I got the PR right: base == main, compare == update-mock-invoice (checking b/c initially GH was routing me to the original stripe-ruby-mock repo)